### PR TITLE
Fix coquille (PR 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [1.0.5] 2025-01-27
+## [1.0.5 to 1.0.6] 2025-01-27
 ### Added
 - Add download date_range:
   ad elements will be scraped only if ad creation_date is between download_start_date and download_end_date.

--- a/nanga_ad_library/__init__.py
+++ b/nanga_ad_library/__init__.py
@@ -7,4 +7,4 @@ from .sdk import NangaAdLibrary
 __all__ = ["NangaAdLibrary"]
 
 # Store package version
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
+++ b/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
@@ -164,7 +164,7 @@ class MetaAdDownloader:
         # Check that creation_date is between __download_start_date et __download_end_date
         creation_date = datetime.strptime(ad_payload.get(self.CREATION_DATE_FIELD), "%Y-%m-%d")
         if not (self.__download_start_date <= creation_date <= self.__download_end_date):
-            ad_payload.update(ad_elements)
+            ad_payload.update({"ad_elements": ad_elements})
             return ad_payload
 
         # Extract preview url from ad payload

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = "nanga-ad-library"
-PACKAGE_VERSION = "1.0.5"
+PACKAGE_VERSION = "1.0.6"
 PACKAGE_AUTHOR = "Nanga"
 PACKAGE_AUTHOR_EMAIL = "hello@spark.do"
 PACKAGE_URL = "https://github.com/Spark-Data-Team/nanga-ad-library"


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes introduced by this PR. -->
Fix coquille from [PR 14](https://github.com/Spark-Data-Team/nanga-ad-library/pull/14)
"ad_elements" key was missing when retrieving data without scraping preview.

## Related Issue
<!-- Link to the issue this PR addresses (e.g., closes #123). -->
--

## Type of Change
<!-- Please delete options that are not relevant. -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Style (formatting, etc.)
- [ ] Other (please specify):

## How Has This Been Tested?
<!-- Describe the tests you've run to verify your changes. -->
--

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
--

## Checklist
- [X] My code follows the project's coding style.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added necessary documentation (if applicable).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass locally with my changes.
- [X] I have updated the package version in [Init](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/nanga_ad_library/__init__.py) and [Setup](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/setup.py) files.
- [X] I have filled the CHANGELOG file

## Additional Information
<!-- Any additional context or information related to this PR. -->
