### PR TITLE
Use delivery_start_date to check ad download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.0.7] 2025-02-25
+### Added
+- Use delivery_start_date to check if the ad has to be downloaded
+
+---
+
 ## [1.0.5 to 1.0.6] 2025-01-27
 ### Added
 - Add download date_range:

--- a/nanga_ad_library/__init__.py
+++ b/nanga_ad_library/__init__.py
@@ -7,4 +7,4 @@ from .sdk import NangaAdLibrary
 __all__ = ["NangaAdLibrary"]
 
 # Store package version
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
+++ b/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
@@ -67,7 +67,7 @@ class MetaAdDownloader:
 
     # Store the fields used to store (1) the Meta Ad Library preview url and (2) the creation date (specific to Meta)
     PREVIEW_FIELD = "ad_snapshot_url"
-    CREATION_DATE_FIELD = "ad_creation_time"
+    DELIVERY_START_DATE_FIELD = "ad_delivery_start_time"
 
     def __init__(self, start_date=None, end_date=None, verbose=False):
         """
@@ -161,9 +161,9 @@ class MetaAdDownloader:
             "carousel": []
         }
 
-        # Check that creation_date is between __download_start_date et __download_end_date
-        creation_date = datetime.strptime(ad_payload.get(self.CREATION_DATE_FIELD), "%Y-%m-%d")
-        if not (self.__download_start_date <= creation_date <= self.__download_end_date):
+        # Check that delivery_start_date is between __download_start_date et __download_end_date
+        delivery_start_date = datetime.strptime(ad_payload.get(self.DELIVERY_START_DATE_FIELD), "%Y-%m-%d")
+        if not (self.__download_start_date <= delivery_start_date <= self.__download_end_date):
             ad_payload.update({"ad_elements": ad_elements})
             return ad_payload
 

--- a/nanga_ad_library/ad_libraries/meta_ad_library.py
+++ b/nanga_ad_library/ad_libraries/meta_ad_library.py
@@ -1148,12 +1148,12 @@ class MetaField(Enum):
     }
     AD_DELIVERY_START_TIME = {
         "name": "ad_delivery_start_time",
-        "mandatory": False,
+        "mandatory": True,
         "warning": None
     }
     AD_DELIVERY_STOP_TIME = {
         "name": "ad_delivery_stop_time",
-        "mandatory": False,
+        "mandatory": True,
         "warning": None
     }
     AD_SNAPSHOT_URL = {

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = "nanga-ad-library"
-PACKAGE_VERSION = "1.0.6"
+PACKAGE_VERSION = "1.0.7"
 PACKAGE_AUTHOR = "Nanga"
 PACKAGE_AUTHOR_EMAIL = "hello@spark.do"
 PACKAGE_URL = "https://github.com/Spark-Data-Team/nanga-ad-library"


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes introduced by this PR. -->
For Meta Ad Library, ads may have been created a long time before they start being delivered.
It's better to use delivery_start_date to enhance the download of ad_elements.

## Related Issue
<!-- Link to the issue this PR addresses (e.g., closes #123). -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactoring
- [ ] Style (formatting, etc.)
- [ ] Other (please specify):

## How Has This Been Tested?
<!-- Describe the tests you've run to verify your changes. -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [X] My code follows the project's coding style.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added necessary documentation (if applicable).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] All new and existing tests pass locally with my changes.
- [X] I have updated the package version in [Init](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/nanga_ad_library/__init__.py) and [Setup](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/setup.py) files.
- [X] I have filled the CHANGELOG file

## Additional Information
<!-- Any additional context or information related to this PR. -->
