### PR TITLE
Detect when Meta blocks Playwright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.0.14] 2025-03-07
+### Added
+- Detect when Meta is blocking Playwright and store the info in ad_elements payload
+
+---
+
 ## [1.0.12 to 1.0.13] 2025-03-06
 ### Added
 - Add new scraping elements:

--- a/nanga_ad_library/__init__.py
+++ b/nanga_ad_library/__init__.py
@@ -7,4 +7,4 @@ from .sdk import NangaAdLibrary
 __all__ = ["NangaAdLibrary"]
 
 # Store package version
-__version__ = "1.0.13"
+__version__ = "1.0.14"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = "nanga-ad-library"
-PACKAGE_VERSION = "1.0.13"
+PACKAGE_VERSION = "1.0.14"
 PACKAGE_AUTHOR = "Nanga"
 PACKAGE_AUTHOR_EMAIL = "hello@spark.do"
 PACKAGE_URL = "https://github.com/Spark-Data-Team/nanga-ad-library"


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes introduced by this PR. -->
Detect when Playwright is blocked by Meta (redirections to Login pages) and retrieve the information in ad_elements payload. 

## Related Issue
<!-- Link to the issue this PR addresses (e.g., closes #123). -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Style (formatting, etc.)
- [ ] Other (please specify):

## How Has This Been Tested?
<!-- Describe the tests you've run to verify your changes. -->

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [X] My code follows the project's coding style.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added necessary documentation (if applicable).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] All new and existing tests pass locally with my changes.
- [X] I have updated the package version in [Init](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/nanga_ad_library/__init__.py) and [Setup](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/setup.py) files.
- [X] I have filled the CHANGELOG file

## Additional Information
<!-- Any additional context or information related to this PR. -->
