### PR TITLE
Slow down ad_elements extraction process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [//]: # (### Security)
 
 [//]: # (- Description of any security issues that were addressed.)
+---
+
+## [1.0.18] 2025-03-18
+### Added
+- Avoid getting flagged by Ad Libraries when downloading ads by slowing the extraction process
 
 ---
 

--- a/nanga_ad_library/__init__.py
+++ b/nanga_ad_library/__init__.py
@@ -7,4 +7,4 @@ from .sdk import NangaAdLibrary
 __all__ = ["NangaAdLibrary"]
 
 # Store package version
-__version__ = "1.0.17"
+__version__ = "1.0.18"

--- a/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
+++ b/nanga_ad_library/ad_downloaders/meta_ad_downloader.py
@@ -172,14 +172,15 @@ class MetaAdDownloader:
                     context = await browser.new_context(user_agent=user_agent)
 
                     try:
-                        # Download ad elements (parallel calls)
-                        updated_batch = await asyncio.gather(
-                            *(self.__download_ad_elements_from_public(context, ad_payload) for ad_payload in ad_downloader_batch)
-                        )
-                        updated_batches.extend(updated_batch)
+                        for ad_payload in ad_downloader_batch:
+                            # Download ad elements 1 by 1
+                            updated_batch = await self.__download_ad_elements_from_public(context, ad_payload)
+                            updated_batches.append(updated_batch)
 
                     finally:
+                        # Close driver context and wait 1 second before next batch
                         await context.close()
+                        time.sleep(1)
 
             finally:
                 await browser.close()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = "nanga-ad-library"
-PACKAGE_VERSION = "1.0.17"
+PACKAGE_VERSION = "1.0.18"
 PACKAGE_AUTHOR = "Nanga"
 PACKAGE_AUTHOR_EMAIL = "hello@spark.do"
 PACKAGE_URL = "https://github.com/Spark-Data-Team/nanga-ad-library"


### PR DESCRIPTION
## Description
Stop parallel calls for data_elements download + add sleep time between batches

## Related Issue


## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactoring
- [ ] Style (formatting, etc.)
- [ ] Other (please specify):

## How Has This Been Tested?

## Screenshots (if applicable)

## Checklist
- [X] My code follows the project's coding style.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added necessary documentation (if applicable).
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] All new and existing tests pass locally with my changes.
- [X] I have updated the package version in [Init](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/nanga_ad_library/__init__.py) and [Setup](https://github.com/Spark-Data-Team/nanga-ad-library/blob/main/setup.py) files.
- [X] I have filled the CHANGELOG file

## Additional Information
